### PR TITLE
C++1x Coroutines and C++11 threading

### DIFF
--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
+  </component>
+</project>

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,5 @@
+cmake_minimum_required(VERSION 3.10)
+project(sigslot)
+set (CMAKE_CXX_STANDARD_REQUIRED C++17)
+include_directories(.)
+add_executable(example test.cc sigslot/sigslot.h)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,10 @@
 cmake_minimum_required(VERSION 3.10)
 project(sigslot)
-set (CMAKE_CXX_STANDARD_REQUIRED C++17)
+
+set (CMAKE_CXX_STANDARD 17)
+add_compile_options(-fcoroutines-ts -stdlib=libc++)
+add_link_options(-fcoroutines-ts -stdlib=libc++)
+
 include_directories(.)
+add_definitions(-DSIGSLOT_COROUTINES)
 add_executable(example test.cc sigslot/sigslot.h)

--- a/test.cc
+++ b/test.cc
@@ -10,8 +10,8 @@ public:
 	 * The template args are a multithreading policy, followed by
 	 * zero or more payload arguments.
 	 */
-	mutable sigslot::signal<sigslot::thread::mt> signal_zero;
-	mutable sigslot::signal<sigslot::thread::mt, bool> signal_bool;
+	mutable sigslot::signal<> signal_zero;
+	mutable sigslot::signal<bool> signal_bool;
 	
 	Source() = default;
 	Source(Source &) = delete;
@@ -33,7 +33,7 @@ public:
 		 */
 		signal_zero();
 	}
-	typedef sigslot::signal<sigslot::thread::mt, Source &, std::string const &, bool> domain_callback_t;
+	typedef sigslot::signal<Source &, std::string const &, bool> domain_callback_t;
 	domain_callback_t & callback(std::string const & domain) {
 		/*
 		 * Sometimes, you might want to have a callback that's
@@ -64,7 +64,7 @@ private:
  * A sink "owns" the signal connections; when it goes out of scope
  * they'll be disconnected.
  */
-class Sink : public sigslot::has_slots<> {
+class Sink : public sigslot::has_slots {
 public:
 	Sink() = default;
 	


### PR DESCRIPTION
* Removed other thread models and just implement based on std::mutex
* Add (optional) support for the coroutine TS, making signals awaitable.