### PR TITLE
Tasklet update

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,10 +1,10 @@
 cmake_minimum_required(VERSION 3.13)
-project(sigslot)
 
 set (CMAKE_CXX_STANDARD 17)
 
 include_directories(.)
 add_executable(example example.cc sigslot/sigslot.h)
+target_link_libraries(example PUBLIC)
 
 add_executable(co_example co_example.cc sigslot/sigslot.h)
 if (UNIX)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,10 +1,10 @@
 cmake_minimum_required(VERSION 3.13)
+project(sigslot)
 
 set (CMAKE_CXX_STANDARD 17)
 
 include_directories(.)
 add_executable(example example.cc sigslot/sigslot.h)
-target_link_libraries(example PUBLIC)
 
 add_executable(co_example co_example.cc sigslot/sigslot.h)
 if (UNIX)

--- a/co_example.cc
+++ b/co_example.cc
@@ -81,7 +81,8 @@ int main(int argc, char *argv[]) {
         std::cout << "M: Executing coroutine." << std::endl;
         auto c = wrapping_coroutine();
         c.start(); // Start the tasklet. It'll execute until it needs to await a signal, then stop and return.
-        // Tasklets automatically start if you get() or co_await them.
+        // Tasklets automatically start if you get() or co_await them, but
+        // if they then suspend you'll get a runtime error.
         std::cout << "M: Coroutine started, now running: " << c.running() << std::endl;
         std::cout << "M: Tick:" << std::endl;
         tick(); // When we emit the signal, it'll start executing the coroutine again. Again, it'll stop when it awaits the next signal.

--- a/co_example.cc
+++ b/co_example.cc
@@ -60,6 +60,7 @@ sigslot::tasklet<int> wrapping_coroutine() {
 sigslot::tasklet<void> throws_exception() {
     std::cout << "I shall throw an exception:" << std::endl;
     throw std::runtime_error("This is an exception.");
+    co_return; // This is unreachable, but needed since otherwise it's not a coroutine!
 }
 
 sigslot::tasklet<bool> catch_exceptions() {
@@ -79,7 +80,8 @@ int main(int argc, char *argv[]) {
          */
         std::cout << "M: Executing coroutine." << std::endl;
         auto c = wrapping_coroutine();
-        c.start(); // Start the coroutine. It'll execute until it needs to await a signal, then stop and return.
+        c.start(); // Start the tasklet. It'll execute until it needs to await a signal, then stop and return.
+        // Tasklets automatically start if you get() or co_await them.
         std::cout << "M: Coroutine started, now running: " << c.running() << std::endl;
         std::cout << "M: Tick:" << std::endl;
         tick(); // When we emit the signal, it'll start executing the coroutine again. Again, it'll stop when it awaits the next signal.

--- a/example.cc
+++ b/example.cc
@@ -39,7 +39,6 @@ public:
 		 * Sometimes, you might want to have a callback that's
 		 * safely decoupled. This is one way of doing this.
 		 */
-		// TODO : Initiate a connect, or whatever.
 		return m_callbacks[domain];
 	}
 	void connect_done(std::string const & domain) {

--- a/sigslot/sigslot.h
+++ b/sigslot/sigslot.h
@@ -249,10 +249,10 @@ namespace sigslot {
                 itNext = it;
                 ++itNext;
 
-                (*it)->emit(a...);
                 if ((*it)->one_shot) {
                     (*it)->expired = true;
                 }
+                (*it)->emit(a...);
 
                 it = itNext;
             }

--- a/sigslot/tasklet.h
+++ b/sigslot/tasklet.h
@@ -8,99 +8,210 @@
 #include <sigslot/sigslot.h>
 #include <experimental/coroutine>
 
+#include <iostream>
+
 namespace sigslot {
+    namespace internal {
 
-    template<typename T>
-    struct tasklet {
-        struct promise_type;
-        using handle_type = std::experimental::coroutine_handle<promise_type>;
-        handle_type coro;
+        template<typename handle_type>
+        struct tasklet {
+            handle_type coro;
 
-        explicit tasklet() : coro(nullptr) {}
-        tasklet(handle_type h) : coro(h) {}
-        tasklet(tasklet && other) : coro(other.coro) {
-            other.coro = nullptr;
-        }
+            explicit tasklet() : coro(nullptr) {}
 
-        tasklet(tasklet const &other) : coro(other.coro) {}
-        tasklet &operator = (tasklet && other) {
-            coro = other.coro;
-            other.coro = nullptr;
-            return *this;
-        }
-        tasklet & operator = (tasklet const &) = delete;
+            tasklet(handle_type h) : coro(h) {}
 
-        ~tasklet() {
-            if (coro) coro.destroy();
-        }
-
-        T get() {
-            return coro.promise().value;
-        }
-
-        void start() {
-            if (!coro) throw std::logic_error("No coroutine to start");
-            if (coro.done()) throw std::logic_error("Already run");
-            coro.resume();
-        }
-
-        bool running() {
-            if (!coro) return false;
-            return !coro.done();
-        }
-
-        sigslot::signal<T> & complete() {
-            return coro.promise().complete;
-        }
-
-        sigslot::signal<std::exception_ptr const &> & exception() {
-            return coro.promise().exception;
-        }
-
-        auto operator co_await() {
-            auto  tmp = coro.promise().complete.operator co_await();
-            if (coro.done()) {
-                tmp.resolve(coro.promise().value);
+            tasklet(tasklet &&other) : coro(other.coro) {
+                other.coro = nullptr;
             }
-            return tmp;
-        }
 
-        void set_name(std::string const & s) {
-            coro.promise().set_name(s);
-        }
+            tasklet(tasklet const &other) : coro(other.coro) {}
 
-        struct promise_type {
+            tasklet &operator=(tasklet &&other) {
+                coro = other.coro;
+                other.coro = nullptr;
+                return *this;
+            }
+
+            tasklet &operator=(tasklet const &) = delete;
+
+            ~tasklet() {
+                if (coro) coro.destroy();
+            }
+
+            auto get() const {
+                return coro.promise().get();
+            }
+
+            void start() {
+                if (!coro) throw std::logic_error("No coroutine to start");
+                if (coro.done()) throw std::logic_error("Already run");
+                coro.resume();
+            }
+
+            bool running() const {
+                if (!coro) return false;
+                return !coro.done();
+            }
+
+            sigslot::signal<> &complete() {
+                return coro.promise().complete;
+            }
+
+            sigslot::signal<std::exception_ptr const &> &exception() {
+                return coro.promise().exception;
+            }
+
+            void set_name(std::string const &s) {
+                coro.promise().set_name(s);
+            }
+
+            auto operator*() const {
+                return get();
+            }
+        };
+
+
+        struct promise_type_base {
             std::string name;
-            T value;
-            sigslot::signal<T> complete;
-            sigslot::signal<std::exception_ptr const &> exception;
-            promise_type() : value() {}
-            void set_name(std::string const & s) {
+            std::exception_ptr eptr;
+            sigslot::signal<> complete;
+            sigslot::signal<std::exception_ptr &> exception;
+
+            void set_name(std::string const &s) {
                 name = s;
             }
-            auto get_return_object() {
-                return tasklet<T>{handle_type::from_promise(*this)};
-            }
-            auto return_value(T v) {
-                value = v;
-                complete(value);
-                return std::experimental::suspend_never{};
-            }
+
             auto final_suspend() {
+                std::cerr << "final_suspend\n";
+                complete();
                 return std::experimental::suspend_always{};
             }
+
             auto initial_suspend() {
+                std::cerr << "initial suspend\n";
                 return std::experimental::suspend_always{};
             }
+
             void unhandled_exception() {
-                exception(std::current_exception());
+                eptr = std::current_exception();
+                exception(eptr);
             }
-            ~promise_type() {
+
+            void get() const {
+                if (eptr) {
+                    std::rethrow_exception(eptr);
+                }
+            }
+
+            ~promise_type_base() {
                 using namespace std::string_literals;
                 name = "** Destroyed **"s;
             }
         };
+
+        template<typename R, typename T>
+        struct promise_type : public promise_type_base {
+            std::string name;
+            T value;
+            std::exception_ptr eptr;
+            sigslot::signal<> complete;
+            sigslot::signal<std::exception_ptr &> exception;
+            typedef std::experimental::coroutine_handle<promise_type<R, T>> handle_type;
+
+            promise_type() : value() {}
+
+            auto get_return_object() {
+                return R{handle_type::from_promise(*this)};
+            }
+
+            auto return_value(T v) {
+                value = v;
+                return std::experimental::suspend_never{};
+            }
+
+            auto get() const {
+                promise_type_base::get();
+                return value;
+            }
+        };
+
+        template<typename R>
+        struct promise_type<R, void> : public promise_type_base {
+            std::string name;
+            std::exception_ptr eptr;
+            sigslot::signal<> complete;
+            sigslot::signal<std::exception_ptr &> exception;
+            typedef std::experimental::coroutine_handle<promise_type<R, void>> handle_type;
+
+            auto get_return_object() {
+                return R{handle_type::from_promise(*this)};
+            }
+
+            auto return_void() {
+                return std::experimental::suspend_never{};
+            }
+        };
+    }
+
+
+    template<typename T>
+    struct tasklet : public internal::tasklet<std::experimental::coroutine_handle<internal::promise_type<tasklet<T>,T>>> {
+        using promise_type = internal::promise_type<tasklet<T>,T>;
+        T operator*() const {
+            return internal::tasklet<std::experimental::coroutine_handle<internal::promise_type<tasklet<T>,T>>>::get();
+        }
     };
+
+    template<>
+    struct tasklet<void> : public internal::tasklet<std::experimental::coroutine_handle<internal::promise_type<tasklet<void>,void>>> {
+        using promise_type = internal::promise_type<tasklet<void>,void>;
+    };
+
+    template<typename T>
+    auto operator co_await(tasklet<T> const &task) {
+        struct awaitable : public has_slots {
+            std::experimental::coroutine_handle<> awaiting = nullptr;
+            tasklet<T> const &task;
+
+            explicit awaitable(tasklet<T> const &t) : task(t) {
+                task.coro.promise().complete.connect(this, &awaitable::resolve);
+            }
+
+            awaitable(awaitable const &a) : task(a.task) {
+                task.coro.promise().complete.connect(this, &awaitable::resolve);
+            }
+
+            awaitable(awaitable &&other) noexcept : task(other.task) {
+                task.coro.promise().complete.connect(this, &awaitable::resolve);
+            }
+
+            bool await_ready() {
+                std::cerr << "await_ready " << (!task.running()) << std::endl;
+                return !task.running();
+            }
+
+            void await_suspend(std::experimental::coroutine_handle<> h) {
+                std::cerr << "await_suspend " << (!task.running()) << std::endl;
+                // The awaiting coroutine is already suspended.
+                awaiting = h;
+            }
+
+            auto await_resume() {
+                std::cerr << "await_resume\n";
+                return task.get();
+            }
+
+            void resolve() {
+                std::cerr << "Resolve()\n";
+                if (awaiting) awaiting.resume();
+            }
+
+            ~awaitable() {
+            }
+        };
+        return awaitable(task);
+    }
 }
 
 #endif //SIGSLOT_TASKLET_H

--- a/sigslot/tasklet.h
+++ b/sigslot/tasklet.h
@@ -8,8 +8,6 @@
 #include <sigslot/sigslot.h>
 #include <experimental/coroutine>
 
-#include <iostream>
-
 namespace sigslot {
     namespace internal {
 
@@ -83,13 +81,11 @@ namespace sigslot {
             }
 
             auto final_suspend() {
-                std::cerr << "final_suspend\n";
                 complete();
                 return std::experimental::suspend_always{};
             }
 
             auto initial_suspend() {
-                std::cerr << "initial suspend\n";
                 return std::experimental::suspend_always{};
             }
 
@@ -187,23 +183,19 @@ namespace sigslot {
             }
 
             bool await_ready() {
-                std::cerr << "await_ready " << (!task.running()) << std::endl;
                 return !task.running();
             }
 
             void await_suspend(std::experimental::coroutine_handle<> h) {
-                std::cerr << "await_suspend " << (!task.running()) << std::endl;
                 // The awaiting coroutine is already suspended.
                 awaiting = h;
             }
 
             auto await_resume() {
-                std::cerr << "await_resume\n";
                 return task.get();
             }
 
             void resolve() {
-                std::cerr << "Resolve()\n";
                 if (awaiting) awaiting.resume();
             }
 

--- a/sigslot/tasklet.h
+++ b/sigslot/tasklet.h
@@ -7,6 +7,7 @@
 
 #include <sigslot/sigslot.h>
 #include <experimental/coroutine>
+#include <string>
 
 namespace sigslot {
     namespace internal {

--- a/sigslot/tasklet.h
+++ b/sigslot/tasklet.h
@@ -181,7 +181,7 @@ namespace sigslot {
                 exception(eptr);
             }
 
-            void get() const {
+            void throw_exception() const {
                 if (eptr) {
                     std::rethrow_exception(eptr);
                 }
@@ -210,7 +210,7 @@ namespace sigslot {
             }
 
             auto get() const {
-                promise_type_base::get();
+                throw_exception();
                 return value;
             }
         };
@@ -226,6 +226,10 @@ namespace sigslot {
             auto return_void() {
                 return std::experimental::suspend_never{};
             }
+
+            void get() const {
+                throw_exception();
+            }
         };
     }
 
@@ -233,7 +237,6 @@ namespace sigslot {
     template<typename T>
     struct tasklet : public internal::tasklet<std::experimental::coroutine_handle<internal::promise_type<tasklet<T>,T>>> {
         using promise_type = internal::promise_type<tasklet<T>,T>;
-        tasklet() = delete;
     };
 
     template<typename T>

--- a/sigslot/tasklet.h
+++ b/sigslot/tasklet.h
@@ -10,7 +10,10 @@
 #include <string>
 
 namespace sigslot {
+    template<typename T> struct tasklet;
+
     namespace internal {
+        template<typename T> struct awaitable;
 
         template<typename handle_type>
         struct tasklet {
@@ -80,6 +83,49 @@ namespace sigslot {
             }
         };
 
+        template<typename T>
+        struct awaitable {
+            std::experimental::coroutine_handle<> awaiting = nullptr;
+            sigslot::tasklet<T> const &task;
+
+            awaitable(sigslot::tasklet<T> const &t) : task(t) {
+                task.coro.promise().await_add(this);
+            }
+
+            awaitable(awaitable const &a) : task(a.task) {
+                task.coro.promise().await_add(this);
+            }
+
+            awaitable(awaitable &&other) noexcept : task(other.task) {
+                task.coro.promise().await_add(this);
+            }
+
+            bool await_ready() {
+                if (!task.started()) {
+                    // Need to start the task
+                    const_cast<sigslot::tasklet<T> &>(task).start();
+                }
+                return !task.running();
+            }
+
+            void await_suspend(std::experimental::coroutine_handle<> h) {
+                // The awaiting coroutine is already suspended.
+                awaiting = h;
+            }
+
+            auto await_resume() {
+                return task.get();
+            }
+
+            void resolve() {
+                if (awaiting) awaiting.resume();
+            }
+
+            ~awaitable() {
+                task.coro.promise().await_del(this);
+            }
+        };
+
 
         struct promise_type_base {
             std::string name;
@@ -121,9 +167,18 @@ namespace sigslot {
         template<typename R, typename T>
         struct promise_type : public promise_type_base {
             T value;
+            std::set<awaitable<T> *> awaiters;
             typedef std::experimental::coroutine_handle<promise_type<R, T>> handle_type;
 
             promise_type() : value() {}
+
+            void await_add(awaitable<T> * a) {
+                awaiters.insert(a);
+            }
+
+            void await_del(awaitable<T> * a) {
+                awaiters.erase(a);
+            }
 
             auto get_return_object() {
                 return R{handle_type::from_promise(*this)};
@@ -143,6 +198,15 @@ namespace sigslot {
         template<typename R>
         struct promise_type<R, void> : public promise_type_base {
             typedef std::experimental::coroutine_handle<promise_type<R, void>> handle_type;
+            std::set<awaitable<void> *> awaiters;
+
+            void await_add(awaitable<void> * a) {
+                awaiters.insert(a);
+            }
+
+            void await_del(awaitable<void> * a) {
+                awaiters.erase(a);
+            }
 
             auto get_return_object() {
                 return R{handle_type::from_promise(*this)};
@@ -163,44 +227,7 @@ namespace sigslot {
 
     template<typename T>
     auto operator co_await(tasklet<T> const &task) {
-        struct awaitable : public has_slots {
-            std::experimental::coroutine_handle<> awaiting = nullptr;
-            tasklet<T> const &task;
-
-            explicit awaitable(tasklet<T> const &t) : task(t) {
-                task.coro.promise().complete.connect(this, &awaitable::resolve);
-            }
-
-            awaitable(awaitable const &a) : task(a.task) {
-                task.coro.promise().complete.connect(this, &awaitable::resolve);
-            }
-
-            awaitable(awaitable &&other) noexcept : task(other.task) {
-                task.coro.promise().complete.connect(this, &awaitable::resolve);
-            }
-
-            bool await_ready() {
-                if (!task.started()) {
-                    // Need to start the task
-                    const_cast<tasklet<T> &>(task).start();
-                }
-                return !task.running();
-            }
-
-            void await_suspend(std::experimental::coroutine_handle<> h) {
-                // The awaiting coroutine is already suspended.
-                awaiting = h;
-            }
-
-            auto await_resume() {
-                return task.get();
-            }
-
-            void resolve() {
-                if (awaiting) awaiting.resume();
-            }
-        };
-        return awaitable(task);
+        return internal::awaitable<T>(task);
     }
 }
 


### PR DESCRIPTION
* Adds a tasklet<void>
* Reworks completion signal

The latter is important for exception handling sanity - it means the caller always gets the result value via the promise_type::get() - ultimately at least - and this means that we can rethrow exceptions here.

Also, the completion signal is emitted during the final_suspend which seems more correct (and this may happen during either an exception or at normal completion).